### PR TITLE
Allow gamepad and keyboard input.

### DIFF
--- a/Game.cpp
+++ b/Game.cpp
@@ -335,7 +335,7 @@ void Game::Update(DX::StepTimer const& timer)
         }
     }
 #ifdef PC
-    else
+    //else
     {
         m_usingGamepad = false;
 


### PR DESCRIPTION
When a gamepad is connected, the demo will not respond to keyboard input.
To allow for both, I commented out the else in Game.cpp (line 338).
